### PR TITLE
Allow for net install from Stata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,17 @@ _Warning:_ The R implementation is currently slightly out of date.
 
 ## Installation
 
-To install the Stata package, clone or download this repo, and then
-copy `bartik_weight.ado` and `bartik_weight.sthlp` to your personal
+Running
+
+```{stata}
+net install bartik_weight, from(https://raw.githubusercontent.com/paulgp/bartik-weight/master/code/)
+```
+
+will add the package  to your personal
 ado folder. You can find this folder using the `sysdir` command.
 
 ## Example
+
 In the code folder, we provide four example do-files that use the
 `bartik_weight` function: `make_rotemberg_summary_ADH.do`,
 `make_rotemberg_summary_BAR.do`,

--- a/code/bartik_weight.pkg
+++ b/code/bartik_weight.pkg
@@ -1,0 +1,6 @@
+v 1
+d bartik_weight estimates the Rotemberg weights outlined in Goldsmith-Pinkham, Sorkin and Swift (2019). Each weight returned corresponds to the misspecification elasticity for each individual instrument when using the Bartik instrument defined by the weights. 
+d Paul Goldsmith-Pinkham, Isaac Sorkin, and Henry Swift
+f bartik_weight.ado
+f bartik_weight.sthlp
+

--- a/code/stata.toc
+++ b/code/stata.toc
@@ -1,0 +1,4 @@
+v 1
+
+d Paul Goldsmith-Pinkham, Isaac Sorkin, and Henry Swift
+p bartik_weight estimates the Rotemberg weights outlined in Goldsmith-Pinkham, Sorkin and Swift (2019). Each weight returned corresponds to the misspecification elasticity for each individual instrument when using the Bartik instrument defined by the weights. 


### PR DESCRIPTION
The manual copying thing is obsolete. This pull request makes the small changes necessary to allow for `net install` for better reproducibility and expedient installation.